### PR TITLE
Ensure read & write timestamp cultures match.

### DIFF
--- a/src/BuildTool/LongtailSync/ReadWriteCurrentVersion.cs
+++ b/src/BuildTool/LongtailSync/ReadWriteCurrentVersion.cs
@@ -47,7 +47,7 @@ internal class ReadWriteCurrentVersion : IMiddleware<LongtailContext>
                 Logger.Warning($"The {versionFilePath} seems to be corrupt. Expected 3 lines, but found {result.Length}. Please delete.");
                 return null;
             }
-            return new(result[0], result[1], DateTime.Parse(result[2]));
+            return new(result[0], result[1], DateTime.Parse(result[2], CultureInfo.InvariantCulture));
         }
     }
 }


### PR DESCRIPTION
- Required for systems with (at very least) `English (United Kingdom)` regional format.